### PR TITLE
Fix to ensure the supporting text fills parent div

### DIFF
--- a/mdl/material.css
+++ b/mdl/material.css
@@ -4274,7 +4274,7 @@ input.mdl-button[type="submit"] {
   line-height: 18px;
   overflow: hidden;
   padding: 16px 16px;
-  width: 90%; }
+  width: 100%; }
 
 .mdl-card__actions {
   font-size: 16px;


### PR DESCRIPTION
Looked odd with centered text within it on https://manmeetgill.com/

@tf2manu994 Was on r/webdev and noticed your site and just couldn't help but make this tweak.
I updated it for your new location of the css files.